### PR TITLE
Normalize URL passed to ContainerRegistry

### DIFF
--- a/coregio/utils.py
+++ b/coregio/utils.py
@@ -2,6 +2,7 @@
 Utilities for http queries
 """
 import logging
+import re
 from typing import Any
 
 from requests import Session
@@ -76,3 +77,18 @@ def add_session_retries(
     adapter = HTTPAdapter(max_retries=retries)
     session.mount("http://", adapter)
     session.mount("https://", adapter)
+
+
+def add_scheme_if_missing(url: str) -> str:
+    """
+    Add https:// to the url if it does not contain a scheme.
+
+    Args:
+        url: Url to check
+
+    Returns:
+        str: Url containing a scheme
+    """
+    if not re.search(r"^[A-Za-z0-9+.\-]+://", url):
+        return f"https://{url}"
+    return url

--- a/tests/test_registry_api.py
+++ b/tests/test_registry_api.py
@@ -8,6 +8,33 @@ from coregio.registry_api import ContainerRegistry
 
 
 @pytest.mark.parametrize(
+    ["url", "expected_url"],
+    [
+        ("quay.io", "https://quay.io"),
+        ("http://quay.io", "http://quay.io"),
+        ("quay.io:8080", "https://quay.io:8080"),
+        ("quay.io/path", "https://quay.io"),
+        ("http://quay.io:8080/path", "http://quay.io:8080"),
+        ("registry-1.docker.io", "https://index.docker.io"),
+        ("hub.docker.com", "https://index.docker.io"),
+        ("registry.hub.docker.com", "https://index.docker.io"),
+        ("docker.io", "https://index.docker.io"),
+        ("http://docker.io", "http://index.docker.io"),
+        ("docker.io:8080", "https://index.docker.io:8080"),
+        ("docker.io/path", "https://index.docker.io"),
+        ("http://docker.io:8080/path", "http://index.docker.io:8080"),
+    ],
+)
+def test__normalize_registry_url(
+    url: str,
+    expected_url: str,
+) -> None:
+    result_url = ContainerRegistry._normalize_registry_url(url)
+
+    assert result_url == expected_url
+
+
+@pytest.mark.parametrize(
     ["registry", "cfg", "auth", "token"],
     [
         ("quay.io", None, None, None),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,3 +18,19 @@ def test_add_session_retries() -> None:
 
     assert reps is None
     assert session.mount.call_count == 2
+
+
+@pytest.mark.parametrize(
+    ["url", "expected_url"],
+    [
+        ("quay.io", "https://quay.io"),
+        ("http://quay.io", "http://quay.io"),
+    ],
+)
+def test_add_scheme_if_missing(
+    url: str,
+    expected_url: str,
+) -> None:
+    result_url = utils.add_scheme_if_missing(url)
+
+    assert result_url == expected_url


### PR DESCRIPTION
This MR adds methods for normalizing the URL passed to ContainerRegistry.

These changes were added mainly so that the special registry hostnames would be correctly replaced even when the passed registry URL contains a scheme or a port number.