### PR TITLE
fix: Add session retries to constructor to avoid starting new connections

### DIFF
--- a/coregio/registry_api.py
+++ b/coregio/registry_api.py
@@ -63,7 +63,12 @@ class ContainerRegistry:
         self._original_url = url
         self.docker_cfg = docker_cfg
 
-        self.session = session or requests.Session()
+        if session:
+            self.session = session
+        else:
+            self.session = requests.Session()
+            utils.add_session_retries(self.session)
+
         self.proxy = proxy
 
         self.auth_header = None
@@ -196,7 +201,6 @@ class ContainerRegistry:
                 auth_token, proxy=self.proxy
             )
         self.session.auth = self._auth_session_cache[auth_class]
-        utils.add_session_retries(self.session)
 
         return self.session
 

--- a/tests/test_registry_api.py
+++ b/tests/test_registry_api.py
@@ -7,6 +7,21 @@ import requests
 from coregio.registry_api import ContainerRegistry
 
 
+def test_init_new_session():
+    registry_api = ContainerRegistry(url="fake_url")
+    adapter = registry_api.session.adapters["https://"]
+
+    assert adapter.max_retries.total == 10
+
+
+def test_init_pass_session():
+    session = requests.Session()
+    registry_api = ContainerRegistry(url="fake_url", session=session)
+    adapter = registry_api.session.adapters["https://"]
+
+    assert adapter.max_retries.total == 0
+
+
 @pytest.mark.parametrize(
     ["url", "expected_url"],
     [


### PR DESCRIPTION
Calling `utils.add_session_retries(self.session)` during `_get_session`, which is called in `_get` causes `urrlib3` to start a new connection every time, leading to wasted resources and drops in performance. Calling it once on the session prevents this.